### PR TITLE
[Feat/#47] 답변 화면, 문답 화면 ViewModel 설계

### DIFF
--- a/app/src/main/java/com/sopt/umbba_android/data/model/response/AnswerResponseDto.kt
+++ b/app/src/main/java/com/sopt/umbba_android/data/model/response/AnswerResponseDto.kt
@@ -1,0 +1,8 @@
+package com.sopt.umbba_android.data.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AnswerResponseDto(
+    val answer: String
+)

--- a/app/src/main/java/com/sopt/umbba_android/data/model/response/QuestionAnswerResponseDto.kt
+++ b/app/src/main/java/com/sopt/umbba_android/data/model/response/QuestionAnswerResponseDto.kt
@@ -1,0 +1,17 @@
+package com.sopt.umbba_android.data.model.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QuestionAnswerResponseDto(
+    val section: String,
+    val topic: String,
+    val opponentQuestion: String,
+    val myQuestion: String,
+    val opponentAnswer: String,
+    val myAnswer: String,
+    val isOpponentAnswer: Boolean,
+    val isMyAnswer: Boolean,
+    val opponentUserName: String,
+    val myUserName: String
+)

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerActivity.kt
@@ -12,12 +12,12 @@ import timber.log.Timber
 
 class AnswerActivity : BindingActivity<ActivityAnswerBinding>(R.layout.activity_answer),
     View.OnClickListener {
-    private val answerViewModel by viewModels <AnswerViewModel>()
+    private val answerViewModel by viewModels<AnswerViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.clickListener = this
         binding.vm = answerViewModel
-        observeText()
+        setQuestionTitle()
     }
 
     override fun onClick(view: View?) {
@@ -27,25 +27,31 @@ class AnswerActivity : BindingActivity<ActivityAnswerBinding>(R.layout.activity_
         }
     }
 
-    private fun observeText(){
-        answerViewModel.inputAnswer.observe(this){
-           Log.e("answer 값",it.toString())
-        }
-    }
-
     private fun showBackDialog() {
         BackAnswerDialogFragment()
             .show(supportFragmentManager, "BackAnswerDialog")
     }
 
+    private fun setQuestionTitle() {
+        with(binding) {
+            tvQuestion.text = intent.getStringExtra("question")
+            tvTitle.text = intent.getStringExtra("topic")
+            layoutAppbar.titleText = intent.getStringExtra("section")
+        }
+    }
+
     private fun showConfirmDialog() {
         val bundle = Bundle()
         val confirmDialog = ConfirmAnswerDialogFragment()
-        bundle.putString("ConfirmAnswerText",answerViewModel.inputAnswer.value.toString())
-        // TODO(API에따라 다르겠지만, 질문 대주제와 소주제, 질문도 dialog에 넘겨줘야함.)
-        confirmDialog.apply{
+        bundle.apply {
+            putString("question", intent.getStringExtra("question"))
+            putString("topic", intent.getStringExtra("topic"))
+            putString("section", intent.getStringExtra("section"))
+            putString("answer", answerViewModel.answer.value)
+        }
+        confirmDialog.apply {
             arguments = bundle
-            show(supportFragmentManager,"ConfirmDialogFragment")
+            show(supportFragmentManager, "ConfirmDialogFragment")
         }
     }
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerActivity.kt
@@ -1,16 +1,23 @@
 package com.sopt.umbba_android.presentation.qna
 
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import androidx.activity.viewModels
+import androidx.lifecycle.viewModelScope
 import com.sopt.umbba_android.R
 import com.sopt.umbba_android.databinding.ActivityAnswerBinding
 import com.sopt.umbba_android.util.binding.BindingActivity
+import timber.log.Timber
 
 class AnswerActivity : BindingActivity<ActivityAnswerBinding>(R.layout.activity_answer),
     View.OnClickListener {
+    private val answerViewModel by viewModels <AnswerViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.clickListener = this
+        binding.vm = answerViewModel
+        observeText()
     }
 
     override fun onClick(view: View?) {
@@ -20,13 +27,25 @@ class AnswerActivity : BindingActivity<ActivityAnswerBinding>(R.layout.activity_
         }
     }
 
+    private fun observeText(){
+        answerViewModel.inputAnswer.observe(this){
+           Log.e("answer 값",it.toString())
+        }
+    }
+
     private fun showBackDialog() {
         BackAnswerDialogFragment()
             .show(supportFragmentManager, "BackAnswerDialog")
     }
 
     private fun showConfirmDialog() {
-        ConfirmAnswerDialogFragment()
-            .show(supportFragmentManager, "ConfirmAnswerDialog")
+        val bundle = Bundle()
+        val confirmDialog = ConfirmAnswerDialogFragment()
+        bundle.putString("ConfirmAnswerText",answerViewModel.inputAnswer.value.toString())
+        // TODO(API에따라 다르겠지만, 질문 대주제와 소주제, 질문도 dialog에 넘겨줘야함.)
+        confirmDialog.apply{
+            arguments = bundle
+            show(supportFragmentManager,"ConfirmDialogFragment")
+        }
     }
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
@@ -1,0 +1,10 @@
+package com.sopt.umbba_android.presentation.qna
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class AnswerViewModel : ViewModel() {
+    private val _inputAnswer = MutableLiveData<String>()
+    val inputAnswer: MutableLiveData<String>
+        get() = _inputAnswer
+}

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
@@ -5,6 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 
 class AnswerViewModel : ViewModel() {
-    private val _answer = MutableLiveData<String>()
-    var answer: LiveData<String> = _answer
+    private var _answer = MutableLiveData<String>()
+    val answer: LiveData<String> = _answer
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
@@ -1,10 +1,11 @@
 package com.sopt.umbba_android.presentation.qna
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.sopt.umbba_android.data.model.response.AnswerResponseDto
 
 class AnswerViewModel : ViewModel() {
-    private val _inputAnswer = MutableLiveData<String>()
-    val inputAnswer: MutableLiveData<String>
-        get() = _inputAnswer
+    private val _answer = MutableLiveData<String>()
+    val answer: LiveData<String> = _answer
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerViewModel.kt
@@ -3,9 +3,8 @@ package com.sopt.umbba_android.presentation.qna
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import com.sopt.umbba_android.data.model.response.AnswerResponseDto
 
 class AnswerViewModel : ViewModel() {
     private val _answer = MutableLiveData<String>()
-    val answer: LiveData<String> = _answer
+    var answer: LiveData<String> = _answer
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
@@ -3,6 +3,7 @@ package com.sopt.umbba_android.presentation.qna
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -11,6 +12,7 @@ import android.view.WindowManager
 import androidx.fragment.app.DialogFragment
 import com.sopt.umbba_android.R
 import com.sopt.umbba_android.databinding.FragmentConfirmAnswerDialogBinding
+import timber.log.Timber
 
 class ConfirmAnswerDialogFragment : DialogFragment() {
 
@@ -29,8 +31,12 @@ class ConfirmAnswerDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         backgroundDesign()
         setBtnClickEvent()
+        setPreviewAnswer()
     }
 
+    private fun setPreviewAnswer(){
+        binding.tvAnswer.text = arguments?.getString("ConfirmAnswerText")
+    }
     private fun backgroundDesign() {
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
     }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
@@ -29,15 +29,16 @@ class ConfirmAnswerDialogFragment : DialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        backgroundDesign()
+        setBackgroundDesign()
         setBtnClickEvent()
         setPreviewAnswer()
     }
 
-    private fun setPreviewAnswer(){
+    private fun setPreviewAnswer() {
         binding.tvAnswer.text = arguments?.getString("ConfirmAnswerText")
     }
-    private fun backgroundDesign() {
+
+    private fun setBackgroundDesign() {
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
     }
 

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
 import com.sopt.umbba_android.R
 import com.sopt.umbba_android.databinding.FragmentConfirmAnswerDialogBinding
 import timber.log.Timber
@@ -17,6 +18,7 @@ import timber.log.Timber
 class ConfirmAnswerDialogFragment : DialogFragment() {
 
     private var _binding: FragmentConfirmAnswerDialogBinding? = null
+    private val confirmAnswerDialogViewModel by viewModels<ConfirmAnswerDialogFragmentViewModel>()
     private val binding get() = requireNotNull(_binding) { "ConfirmAnswerDialogFragment is null" }
 
     override fun onCreateView(
@@ -30,12 +32,16 @@ class ConfirmAnswerDialogFragment : DialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setBackgroundDesign()
-        setBtnClickEvent()
         setPreviewAnswer()
+        setBtnClickEvent()
     }
 
     private fun setPreviewAnswer() {
-        binding.tvAnswer.text = arguments?.getString("ConfirmAnswerText")
+        with(binding) {
+            tvAnswer.text = arguments?.getString("answer")
+            tvTitle.text = arguments?.getString("title")
+            tvTopic.text = arguments?.getString("topic")
+        }
     }
 
     private fun setBackgroundDesign() {
@@ -49,7 +55,7 @@ class ConfirmAnswerDialogFragment : DialogFragment() {
             }
             btnConfirm.setOnClickListener {
                 dismiss()
-                //TODO(답변 내용 POST API 연결 부분)
+                confirmAnswerDialogViewModel.postAnswer(tvAnswer.text.toString())
             }
         }
     }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragmentViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragmentViewModel.kt
@@ -1,0 +1,9 @@
+package com.sopt.umbba_android.presentation.qna
+
+import androidx.lifecycle.ViewModel
+
+class ConfirmAnswerDialogFragmentViewModel : ViewModel() {
+    fun postAnswer(answer: String) {
+        //TODO(post Repo로 가는 함수 가보자고.)
+    }
+}

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerActivity.kt
@@ -18,7 +18,6 @@ class QuestionAnswerActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.clickListener = this
-        setClickEvent()
         observeQnaResponse()
     }
 
@@ -28,12 +27,13 @@ class QuestionAnswerActivity :
         }
     }
 
-    private fun setClickEvent() {
+    private fun setClickEvent(data: QuestionAnswerResponseDto) {
         with(binding) {
             btnAnswer.setOnClickListener {
                 Intent(this@QuestionAnswerActivity, AnswerActivity::class.java).apply {
-                    putExtra("section", binding.titleText.toString())
-                    putExtra("topic",binding.layoutAppbar.titleText.toString())
+                    putExtra("section", data.section)
+                    putExtra("topic", data.topic)
+                    putExtra("question", data.myQuestion)
                     startActivity(this)
                 }
             }
@@ -44,6 +44,7 @@ class QuestionAnswerActivity :
         questionAnswerViewModel.qnaResponse.observe(this@QuestionAnswerActivity) {
             setData(it)
             setAnswerText(it)
+            setClickEvent(it)
         }
     }
 

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerActivity.kt
@@ -4,7 +4,9 @@ import android.content.Intent
 import android.graphics.BlurMaskFilter
 import android.os.Bundle
 import android.view.View
+import androidx.activity.viewModels
 import com.sopt.umbba_android.R
+import com.sopt.umbba_android.data.model.response.QuestionAnswerResponseDto
 import com.sopt.umbba_android.databinding.ActivityQuestionAnswerBinding
 import com.sopt.umbba_android.util.binding.BindingActivity
 
@@ -12,11 +14,12 @@ import com.sopt.umbba_android.util.binding.BindingActivity
 class QuestionAnswerActivity :
     BindingActivity<ActivityQuestionAnswerBinding>(R.layout.activity_question_answer),
     View.OnClickListener {
+    private val questionAnswerViewModel by viewModels<QuestionAnswerViewModel>()
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.clickListener = this
-        setBlurText(false)
         setClickEvent()
+        observeQnaResponse()
     }
 
     override fun onClick(view: View?) {
@@ -28,7 +31,47 @@ class QuestionAnswerActivity :
     private fun setClickEvent() {
         with(binding) {
             btnAnswer.setOnClickListener {
-                startActivity(Intent(this@QuestionAnswerActivity, AnswerActivity::class.java))
+                Intent(this@QuestionAnswerActivity, AnswerActivity::class.java).apply {
+                    putExtra("section", binding.titleText.toString())
+                    putExtra("topic",binding.layoutAppbar.titleText.toString())
+                    startActivity(this)
+                }
+            }
+        }
+    }
+
+    private fun observeQnaResponse() {
+        questionAnswerViewModel.qnaResponse.observe(this@QuestionAnswerActivity) {
+            setData(it)
+            setAnswerText(it)
+        }
+    }
+
+    private fun setData(data: QuestionAnswerResponseDto) {
+        with(binding) {
+            layoutAppbar.titleText = data.topic
+            tvTitle.text = data.section
+            tvQuestionMe.text = data.myQuestion
+            tvQuestionOther.text = data.opponentQuestion
+        }
+    }
+
+    private fun setAnswerText(data: QuestionAnswerResponseDto) {
+        with(binding) {
+            if (data.isOpponentAnswer) {
+                if (data.isMyAnswer) {
+                    tvAnswerMe.text = data.myAnswer
+                    tvAnswerOther.text = data.opponentAnswer
+                } else {
+                    tvAnswerOther.text = data.opponentAnswer
+                    tvAnswerMe.text = "답변을 입력해 주세요"
+                    setBlurText(true)
+                }
+            } else {
+                if (data.isMyAnswer) {
+                    tvAnswerMe.text = data.myAnswer
+                    tvAnswerOther.text = "상대방은 아직 답변하지 않았어요"
+                }
             }
         }
     }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
@@ -1,0 +1,11 @@
+package com.sopt.umbba_android.presentation.qna
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.sopt.umbba_android.data.model.response.QuestionAnswerResponseDto
+
+class QuestionAnswerViewModel : ViewModel() {
+    private val _qnaResponse = MutableLiveData<QuestionAnswerResponseDto>()
+    val qnaResponse : LiveData<QuestionAnswerResponseDto> = _qnaResponse
+}

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
@@ -7,5 +7,5 @@ import com.sopt.umbba_android.data.model.response.QuestionAnswerResponseDto
 
 class QuestionAnswerViewModel : ViewModel() {
     private val _qnaResponse = MutableLiveData<QuestionAnswerResponseDto>()
-    val qnaResponse: LiveData<QuestionAnswerResponseDto> = _qnaResponse
+    var qnaResponse: LiveData<QuestionAnswerResponseDto> = _qnaResponse
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
@@ -6,6 +6,6 @@ import androidx.lifecycle.ViewModel
 import com.sopt.umbba_android.data.model.response.QuestionAnswerResponseDto
 
 class QuestionAnswerViewModel : ViewModel() {
-    private val _qnaResponse = MutableLiveData<QuestionAnswerResponseDto>()
-    var qnaResponse: LiveData<QuestionAnswerResponseDto> = _qnaResponse
+    private var _qnaResponse = MutableLiveData<QuestionAnswerResponseDto>()
+    val qnaResponse: LiveData<QuestionAnswerResponseDto> = _qnaResponse
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerViewModel.kt
@@ -7,5 +7,5 @@ import com.sopt.umbba_android.data.model.response.QuestionAnswerResponseDto
 
 class QuestionAnswerViewModel : ViewModel() {
     private val _qnaResponse = MutableLiveData<QuestionAnswerResponseDto>()
-    val qnaResponse : LiveData<QuestionAnswerResponseDto> = _qnaResponse
+    val qnaResponse: LiveData<QuestionAnswerResponseDto> = _qnaResponse
 }

--- a/app/src/main/res/layout/activity_answer.xml
+++ b/app/src/main/res/layout/activity_answer.xml
@@ -6,6 +6,10 @@
     <data>
 
         <variable
+            name="vm"
+            type="com.sopt.umbba_android.presentation.qna.AnswerViewModel" />
+
+        <variable
             name="titleText"
             type="String" />
 
@@ -85,11 +89,13 @@
                 app:layout_constraintTop_toTopOf="parent">
 
                 <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/et_answer"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:gravity="left"
                     android:hint="@string/answer_edittext_hint"
                     android:minHeight="172dp"
+                    android:text="@={vm.inputAnswer}"
                     android:textAppearance="@style/AndroidBody1_2Regular16"
                     android:textColorHint="@color/grey_800"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/activity_answer.xml
+++ b/app/src/main/res/layout/activity_answer.xml
@@ -95,7 +95,7 @@
                     android:gravity="left"
                     android:hint="@string/answer_edittext_hint"
                     android:minHeight="172dp"
-                    android:text="@={vm.inputAnswer}"
+                    android:text="@={vm.answer}"
                     android:textAppearance="@style/AndroidBody1_2Regular16"
                     android:textColorHint="@color/grey_800"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,7 +73,7 @@
     <string name="question_answer_parent_question">할머니와 엄마의 꿈은 달랐어?</string>
     <string name="question_answer_quesiton_me">당신과 어머니의 꿈은 달라?</string>
     <string name="content_example">sdlkfjslkdjfklsdjfksdf\nsldkfjsldkjflksdjf</string>
-    <string name="home_question_answer">질문 답변하기</string>
+    <string name="home_question_answer">질문 확인하기</string>
 
     <!--invite code dialog fragment-->
     <string name="not_have_partner">상대에게 교신을 보낼 차례야\n초대를 수락받으면 문답이 시작돼</string>
@@ -90,7 +90,7 @@
     <string name="question_number">#%d</string>
 
     <!-- back answer dialog fragment-->
-    <string name="back_confirm">답변 작성을 취소하시겠습니까?\n작성 중인 답변은 저장되지 않아요</string>
+    <string name="back_confirm">답변 작성을 취소하시겠어요?\n작성 중인 답변은 저장되지 않아요</string>
     <string name="cancel">취소</string>
     <string name="confirm">확인</string>
     <string name="on">On</string>


### PR DESCRIPTION
## 🎀 Related Issues

#### close #47 

## 🤔 What Did You Do
- [x] 답변 화면 ViewModel 구현 
- [x] 문답 화면 ViewModel 구현
- [x] 답변 저장 Dialog ViewModel 구현
- [x] 문답->답변->저장 dialog 데이터 전달 구현 

## ⁉️ etc
- 임시 api 명세서 바탕으로 responseDto 만들어서 viewModel을 작성해봤습니다.

- 문답 화면에서는 사용자 status에 따른 blur 처리 부분 로직을 중점적으로 봐주시면 좋을거같습니다.

- 전체적으로는 문답 화면으로부터 section과 topic, question 데이터가 답변 화면, dialog까지 계속 넘어가야하는데 이 부분 로직도 봐주시면 좋겠습니다.