### PR TITLE
[Feat/#75] 회원탈퇴 API 연결, 답변 확인 로직 수정

### DIFF
--- a/app/src/main/java/com/sopt/umbba_android/data/local/SharedPreferences.kt
+++ b/app/src/main/java/com/sopt/umbba_android/data/local/SharedPreferences.kt
@@ -62,4 +62,8 @@ object SharedPreferences {
         clear()
         setBoolean(LoginActivity.DID_USER_CLEAR_ONBOARD, true)
     }
+
+    fun clearForSignout(){
+        clear()
+    }
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/AnswerActivity.kt
@@ -42,7 +42,6 @@ class AnswerActivity : BindingActivity<ActivityAnswerBinding>(R.layout.activity_
             tvTopic.text = intent.getStringExtra("topic")
             viewModel.appbarTitle.value = intent.getStringExtra("section")
             layoutAppbar.titleText = viewModel.appbarTitle.value
-            Log.e("hyeon", intent.getStringExtra("section").toString())
         }
     }
 

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
@@ -19,7 +19,7 @@ import com.sopt.umbba_android.util.ViewModelFactory
 class ConfirmAnswerDialogFragment : DialogFragment() {
 
     private var _binding: FragmentConfirmAnswerDialogBinding? = null
-    private val answerViewModel: ConfirmAnswerDialogFragmentViewModel by viewModels {
+    private val viewModel: ConfirmAnswerDialogFragmentViewModel by viewModels {
         ViewModelFactory(
             requireActivity()
         )
@@ -39,6 +39,16 @@ class ConfirmAnswerDialogFragment : DialogFragment() {
         setBackgroundDesign()
         setPreviewAnswer()
         setBtnClickEvent()
+        observeResponseStatus()
+    }
+
+    private fun observeResponseStatus() {
+        viewModel.responseStatus.observe(this) {
+            if (it == 201) {
+                dismiss()
+                requireActivity().finish()
+            }
+        }
     }
 
     private fun setPreviewAnswer() {
@@ -61,10 +71,7 @@ class ConfirmAnswerDialogFragment : DialogFragment() {
             }
             btnConfirm.setOnClickListener {
                 Toast.makeText(requireActivity(), "답변이 전송되었습니다.", Toast.LENGTH_SHORT).show()
-                answerViewModel.postAnswer(AnswerRequestDto(arguments?.getString("answer")))
-                Log.e("hyeon", "answer 값은 = ${arguments?.getString("answer")}")
-                activity?.finish()
-                dismiss()
+                viewModel.postAnswer(AnswerRequestDto(arguments?.getString("answer")))
             }
         }
     }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/QuestionAnswerActivity.kt
@@ -150,4 +150,9 @@ class QuestionAnswerActivity :
             }
         }
     }
+
+    override fun onResume() {
+        super.onResume()
+        observeQnaViewFlag()
+    }
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/viewmodel/ConfirmAnswerDialogFragmentViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/viewmodel/ConfirmAnswerDialogFragmentViewModel.kt
@@ -1,6 +1,7 @@
 package com.sopt.umbba_android.presentation.qna.viewmodel
 
 import android.util.Log
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sopt.umbba_android.data.model.request.AnswerRequestDto
@@ -9,13 +10,17 @@ import kotlinx.coroutines.launch
 
 class ConfirmAnswerDialogFragmentViewModel(private val questionAnswerRepositoryImpl: QuestionAnswerRepositoryImpl) :
     ViewModel() {
+
+    var responseStatus = MutableLiveData<Int>()
     fun postAnswer(answerRequestDto: AnswerRequestDto) {
         viewModelScope.launch {
             questionAnswerRepositoryImpl.postAnswer(answerRequestDto)
-                .onSuccess {
+                .onSuccess { reseponse ->
                     Log.e("hyeon", "postAnswer 성공")
+                    responseStatus.value = reseponse.status
                 }.onFailure { error ->
                     Log.e("hyeon", "postAnswer 실패  " + error.message)
+                    responseStatus.value = -1
                 }
         }
     }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/setting/DeleteAccountActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/setting/DeleteAccountActivity.kt
@@ -14,7 +14,7 @@ import com.sopt.umbba_android.util.binding.BindingActivity
 
 class DeleteAccountActivity :
     BindingActivity<ActivityDeleteAccountBinding>(R.layout.activity_delete_account),
-    View.OnClickListener, DeleteAccountDialogFragment.OnSignOutListener {
+    View.OnClickListener {
     private val viewModel: DeleteAccountViewModel by viewModels { ViewModelFactory(this) }
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,20 +26,8 @@ class DeleteAccountActivity :
         with(binding) {
             btnDeleteAccount.setOnClickListener {
                 DeleteAccountDialogFragment().apply{
-                    setOnSignOutListener(this@DeleteAccountActivity)
                     show(supportFragmentManager, "DeleteAccountDialog")
                 }
-            }
-        }
-    }
-
-    private fun observeResponseStatus() {
-        viewModel.responseStatus.observe(this@DeleteAccountActivity) {
-            Log.e("hyeon", "responseStatus값은" + viewModel.responseStatus.value)
-            if (it == 200) {
-                val intent = Intent(this, LoginActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                startActivity(intent)
             }
         }
     }
@@ -52,11 +40,4 @@ class DeleteAccountActivity :
         }
     }
 
-    override fun onSignOutConfirmed() {
-        // 여기에 로그아웃 후 할 로직 작성하면될듯
-        val intent = Intent(this, LoginActivity::class.java)
-        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
-        startActivity(intent)
-        finish()
-    }
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/setting/DeleteAccountDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/setting/DeleteAccountDialogFragment.kt
@@ -12,6 +12,7 @@ import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
+import com.sopt.umbba_android.data.local.SharedPreferences
 import com.sopt.umbba_android.databinding.FragemntDeleteAccountDialogBinding
 import com.sopt.umbba_android.presentation.login.LoginActivity
 import com.sopt.umbba_android.presentation.setting.viewmodel.DeleteAccountViewModel
@@ -55,9 +56,10 @@ class DeleteAccountDialogFragment : DialogFragment() {
         }
     }
 
-    private fun observeResponseStatus(){
-        viewModel.responseStatus.observe(this){
-            if (it==200){
+    private fun observeResponseStatus() {
+        viewModel.responseStatus.observe(this) {
+            if (it == 200) {
+                SharedPreferences.clearForSignout()
                 val intent = Intent(requireActivity(), LoginActivity::class.java)
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 startActivity(intent)

--- a/app/src/main/java/com/sopt/umbba_android/presentation/setting/DeleteAccountDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/setting/DeleteAccountDialogFragment.kt
@@ -23,7 +23,6 @@ class DeleteAccountDialogFragment : DialogFragment() {
 
     private val viewModel: DeleteAccountViewModel by viewModels { ViewModelFactory(requireActivity()) }
     private var _binding: FragemntDeleteAccountDialogBinding? = null
-    private var signOutListener: DeleteAccountDialogFragment.OnSignOutListener? = null
     private val binding get() = requireNotNull(_binding) { "DeleteAccountDialogFragment is null" }
 
     override fun onCreateView(
@@ -38,6 +37,7 @@ class DeleteAccountDialogFragment : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         backgroundDesign()
         setBtnClickEvent()
+        observeResponseStatus()
     }
 
     private fun backgroundDesign() {
@@ -51,11 +51,16 @@ class DeleteAccountDialogFragment : DialogFragment() {
             }
             btnConfirm.setOnClickListener {
                 viewModel.signout()
-                dismiss()
-                val intent = Intent(requireContext(), LoginActivity::class.java)
-                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        }
+    }
+
+    private fun observeResponseStatus(){
+        viewModel.responseStatus.observe(this){
+            if (it==200){
+                val intent = Intent(requireActivity(), LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 startActivity(intent)
-                requireActivity().finish()
             }
         }
     }
@@ -71,13 +76,5 @@ class DeleteAccountDialogFragment : DialogFragment() {
     override fun onDestroy() {
         super.onDestroy()
         _binding = null
-    }
-
-    fun setOnSignOutListener(listener: DeleteAccountDialogFragment.OnSignOutListener) {
-        this.signOutListener = listener
-    }
-
-    interface OnSignOutListener {
-        fun onSignOutConfirmed()
     }
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/setting/ManageAccountActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/setting/ManageAccountActivity.kt
@@ -7,6 +7,7 @@ import android.view.View
 import android.widget.Toast
 import androidx.activity.viewModels
 import com.sopt.umbba_android.R
+import com.sopt.umbba_android.data.local.SharedPreferences
 import com.sopt.umbba_android.databinding.ActivityManageAccountBinding
 import com.sopt.umbba_android.presentation.login.LoginActivity
 import com.sopt.umbba_android.presentation.setting.viewmodel.ManageAccountViewModel
@@ -33,6 +34,7 @@ class ManageAccountActivity :
     private fun observeResponseStatus() {
         viewModel.responseStatus.observe(this@ManageAccountActivity) {
             if (it == 200) {
+                SharedPreferences.clearForLogout()
                 val intent = Intent(this, LoginActivity::class.java)
                 intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 startActivity(intent)

--- a/app/src/main/java/com/sopt/umbba_android/presentation/setting/SettingFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/setting/SettingFragment.kt
@@ -27,11 +27,13 @@ class SettingFragment : BindingFragment<FragmentSettingBinding>(R.layout.fragmen
         setClickEvent()
     }
 
-    private val notificationSettingsLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
-        // 앱의 설정 화면으로 이동한 후 결과를 처리하는 로직
-        Log.e("hyeon","나 지금 돌아왔어요.")
-        setSwitchNotification()
-    }
+    private val notificationSettingsLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            // 앱의 설정 화면으로 이동한 후 결과를 처리하는 로직
+            Log.e("hyeon", "나 지금 돌아왔어요.")
+            setSwitchNotification()
+        }
+
     private fun setSwitchNotification() {
         binding.switchNotification.isChecked = ContextCompat.checkSelfPermission(
             requireActivity(),
@@ -42,13 +44,15 @@ class SettingFragment : BindingFragment<FragmentSettingBinding>(R.layout.fragmen
 
     private fun changeSwitchNotification() {
         binding.switchNotification.setOnCheckedChangeListener { buttonView, isChecked ->
-            if (isChecked !=  (ContextCompat.checkSelfPermission(
+            if (isChecked != (ContextCompat.checkSelfPermission(
                     requireActivity(),
                     Manifest.permission.POST_NOTIFICATIONS
-                ) == PackageManager.PERMISSION_GRANTED)){
-                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).setData(Uri.parse("package:" + requireActivity().packageName))
+                ) == PackageManager.PERMISSION_GRANTED)
+            ) {
+                val intent =
+                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).setData(Uri.parse("package:" + requireActivity().packageName))
                 notificationSettingsLauncher.launch(intent)
-                Log.e("hyeon","나 지금 switch 바꿨어요.")
+                Log.e("hyeon", "나 지금 switch 바꿨어요.")
             }
         }
     }
@@ -62,7 +66,7 @@ class SettingFragment : BindingFragment<FragmentSettingBinding>(R.layout.fragmen
                 startActivity(
                     Intent(
                         Intent.ACTION_VIEW,
-                        Uri.parse("https://www.notion.so/f1a14bf60ed4421f9b3761ef88906adb")
+                        Uri.parse("https://brawny-guan-098.notion.site/7b3e5f70a471468f8acbe56a1a4f4ec9?pvs=4")
                     )
                 )
             }
@@ -74,11 +78,11 @@ class SettingFragment : BindingFragment<FragmentSettingBinding>(R.layout.fragmen
                     )
                 )
             }
-            clNotice.setOnClickListener {
+            clPrivacyNotice.setOnClickListener {
                 startActivity(
                     Intent(
                         Intent.ACTION_VIEW,
-                        Uri.parse("https://www.notion.so/f1a14bf60ed4421f9b3761ef88906adb")
+                        Uri.parse("https://www.notion.so/99fe0f58825d4f87bd3b987fadc623b6?pvs=4")
                     ) //공지사항 바꾸기
                 )
             }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/setting/viewmodel/DeleteAccountViewModel.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/setting/viewmodel/DeleteAccountViewModel.kt
@@ -21,13 +21,11 @@ class DeleteAccountViewModel(private val settingRepositoryImpl: SettingRepositor
             settingRepositoryImpl.signout()
                 .onSuccess { response ->
                     Log.e("hyeon", "viewModel 회원탈퇴 성공")
+                    responseStatus.value = response.status
                 }.onFailure { error ->
                     Log.e("hyeon", "viewModel 회원탈퇴 실패  " + error.message)
+                    responseStatus.value = -1
                 }
         }
-    }
-    override fun onCleared() {
-        super.onCleared()
-        // ViewModel이 소멸될 때 CoroutineScope에서 관리하는 코루틴 취소
     }
 }

--- a/app/src/main/java/com/sopt/umbba_android/util/ViewModelFactory.kt
+++ b/app/src/main/java/com/sopt/umbba_android/util/ViewModelFactory.kt
@@ -24,6 +24,7 @@ import com.sopt.umbba_android.presentation.login.viewmodel.LoginViewModel
 import com.sopt.umbba_android.presentation.qna.viewmodel.AnswerViewModel
 import com.sopt.umbba_android.presentation.qna.viewmodel.ConfirmAnswerDialogFragmentViewModel
 import com.sopt.umbba_android.presentation.qna.viewmodel.QuestionAnswerViewModel
+import com.sopt.umbba_android.presentation.setting.viewmodel.DeleteAccountViewModel
 import com.sopt.umbba_android.presentation.setting.viewmodel.ManageAccountViewModel
 
 class ViewModelFactory(private val context: Context) : ViewModelProvider.Factory {
@@ -79,6 +80,13 @@ class ViewModelFactory(private val context: Context) : ViewModelProvider.Factory
 
         if (modelClass.isAssignableFrom(ManageAccountViewModel::class.java)) {
             return ManageAccountViewModel(
+                SettingRepositoryImpl(
+                    SettingRemoteDataSource()
+                )
+            ) as T
+        }
+        if (modelClass.isAssignableFrom(DeleteAccountViewModel::class.java)) {
+            return DeleteAccountViewModel(
                 SettingRepositoryImpl(
                     SettingRemoteDataSource()
                 )

--- a/app/src/main/java/com/sopt/umbba_android/util/fcm/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/sopt/umbba_android/util/fcm/MyFirebaseMessagingService.kt
@@ -80,11 +80,11 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     private fun getFcmToken() {
         FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
             if (!task.isSuccessful) {
-                Timber.tag("hyeon").e(task.exception, "Fetching FCM registration token failed")
+                Log.e("hyeon", "Fetching FCM registration token failed")
                 return@OnCompleteListener
             }
             val token = task.result
-            Timber.tag("hyeon").e("token is " + token)
+            Log.e("hyeon", "token is " + token)
         })
     }
 

--- a/app/src/main/res/layout/fragment_setting.xml
+++ b/app/src/main/res/layout/fragment_setting.xml
@@ -175,7 +175,7 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/cl_notice"
+            android:id="@+id/cl_privacy_notice"
             android:layout_width="match_parent"
             android:layout_height="72dp"
             android:background="@drawable/sel_background_bottom_stroke"
@@ -190,7 +190,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="24dp"
                 android:layout_marginTop="26dp"
-                android:text="@string/setting_notice"
+                android:text="@string/setting_privacy_notice"
                 android:textAppearance="@style/AndroidBody1_2Regular16"
                 android:textColor="@color/umbba_black"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,7 +59,7 @@
     <string name="setting_notification">알람 설정</string>
     <string name="setting_about_umbba">About 엄빠도 어렸다</string>
     <string name="setting_tos">이용약관</string>
-    <string name="setting_notice">공지사항</string>
+    <string name="setting_privacy_notice">개인정보 처리방침</string>
 
     <!-- answer activity-->
     <string name="answer_edittext_hint">상대방은 아직 답변하지 않았어요</string>


### PR DESCRIPTION
## 🎀 Related Issues

#### close #83 #75 

## 🤔 What Did You Do
- [x]  회원탈퇴 API 연결
- [x] 코루틴 job was cancelled 해결하기 
- [x] 회원탈퇴  SharedPreference clear
- [x] 로그아웃 SharedPreference clear
- [x]  답변 전송 시 코루틴 중단 에러 해결 
- [x] dialog dismiss 후 문답 화면으로 돌아가도록 하기
- [x] 문답 화면에 돌아올 때 답변 값 들어오도록 하기
- [x] 설정 뷰 공지사항 -> 개인정보처리방침으로 변경 (기획측 요청)

## ⁉️ etc
- 브랜치 번호 나눈다는걸 실수해서 75로 같이 푸쉬해버렸습니다.. 그래서 같이 올려요