### PR TITLE
[Fix/#103] 온보딩 시간 설정 오류 수정

### DIFF
--- a/app/src/main/java/com/sopt/umbba_android/presentation/home/InviteCodeDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/home/InviteCodeDialogFragment.kt
@@ -76,7 +76,7 @@ class InviteCodeDialogFragment(private val inviteUserName: String, private val i
                 content = Content(
                     title = getString(R.string.kakao_title, inviteUserName, inviteCode),
                     description = getString(R.string.kakao_description),
-                    imageUrl = "https://github.com/Team–Umbba/Umbba–iOS/assets/75068759/64ba7265–9148–4f06–8235-de5f4030e92f",
+                    imageUrl = "https://github.com/Team-Umbba/Umbba-iOS/assets/75068759/64ba7265-9148-4f06-8235-de5f4030e92f",
                     link = Link(
                         webUrl = "https://developers.kakao.com",
                         mobileWebUrl = "https://developers.kakao.com"

--- a/app/src/main/java/com/sopt/umbba_android/presentation/onboarding/SetTimeActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/onboarding/SetTimeActivity.kt
@@ -136,7 +136,8 @@ class SetTimeActivity : BindingActivity<ActivitySetTimeBinding>(R.layout.activit
             if (it) {
                 setOnboardingBoolean(DID_USER_CLEAR_ONBOARD, true)
                 setOnboardingBoolean(DID_USER_CLEAR_INVITE_CODE, true)
-                startActivity(Intent(this, OnboardingFinishActivity::class.java))
+                startActivity(Intent(this, OnboardingFinishActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK))
             } else {
                 Snackbar.make(binding.root, R.string.fail_information_post, Snackbar.LENGTH_SHORT).show()
             }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/onboarding/SetTimeActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/onboarding/SetTimeActivity.kt
@@ -7,7 +7,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
-import android.util.Log
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
@@ -35,10 +34,13 @@ class SetTimeActivity : BindingActivity<ActivitySetTimeBinding>(R.layout.activit
     private val requestPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
             if (isGranted) {
+                //권한을 승인할 경우
                 Snackbar.make(binding.root, R.string.allow_notification, Snackbar.LENGTH_SHORT).show()
             } else {
+                //권한을 거절할 경우
                 Snackbar.make(binding.root, R.string.not_allow_notification, Snackbar.LENGTH_SHORT).show()
             }
+            sendUserData()
         }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -66,21 +68,22 @@ class SetTimeActivity : BindingActivity<ActivitySetTimeBinding>(R.layout.activit
     }
 
     private fun askNotificationPermission() {
-        if (ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) == PackageManager.PERMISSION_GRANTED
-        ) {
-            Snackbar.make(binding.root, getString(R.string.allowing_notification), Snackbar.LENGTH_SHORT).show()
-        }
-
-        if (ContextCompat.checkSelfPermission(
-                this,
-                Manifest.permission.POST_NOTIFICATIONS
-            ) != PackageManager.PERMISSION_GRANTED){
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            //권한이 허용되어 있는 경우
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    Manifest.permission.POST_NOTIFICATIONS
+                ) == PackageManager.PERMISSION_GRANTED
+            ) {
+                Snackbar.make(
+                    binding.root,
+                    getString(R.string.allowing_notification),
+                    Snackbar.LENGTH_SHORT
+                ).show()
+                sendUserData()
+            } else {
                 if (shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)) {
-                    // 왜 알림을 허용해야 하는지에 대한 설명 + 권한 거절 시 권한 설정 화면으로 이동
+                    // 이미 한번 권한을 거절한 경우
                     Snackbar.make(
                         binding.root,
                         getString(R.string.if_allow_notification),
@@ -93,13 +96,7 @@ class SetTimeActivity : BindingActivity<ActivitySetTimeBinding>(R.layout.activit
                 } else {
                     requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 }
-            }
-            else{
-                Snackbar.make(
-                    binding.root,
-                    getString(R.string.setting_noti),
-                    Snackbar.LENGTH_SHORT
-                ).show()
+
             }
         }
     }
@@ -108,7 +105,7 @@ class SetTimeActivity : BindingActivity<ActivitySetTimeBinding>(R.layout.activit
         val hour =
             if (binding.tpTime.hour == 0) {
                 "24"
-            } else if (binding.tpTime.hour in 1..9){
+            } else if (binding.tpTime.hour in 1..9) {
                 "0${binding.tpTime.hour}"
             } else {
                 binding.tpTime.hour
@@ -128,27 +125,30 @@ class SetTimeActivity : BindingActivity<ActivitySetTimeBinding>(R.layout.activit
         }
     }
 
+    private fun sendUserData() {
+        val userData = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            intent.getParcelableExtra("userData", User::class.java)
+        } else {
+            intent.getParcelableExtra<User>("userData")
+        }
+        setTime()
+        val questData = intent.getStringArrayExtra("questData")
+        setQuestList(questData)
+        viewModel.setSendInfo(userData, time, questList)
+        viewModel.isPostSuccess.observe(this) {
+            if (it) {
+                setOnboardingBoolean(DID_USER_CLEAR_ONBOARD, true)
+                setOnboardingBoolean(DID_USER_CLEAR_INVITE_CODE, true)
+                startActivity(Intent(this, OnboardingFinishActivity::class.java))
+            } else {
+                Snackbar.make(binding.root, R.string.fail_information_post, Snackbar.LENGTH_SHORT).show()
+            }
+        }
+    }
+
     private fun goOnboardingFinishActivity() {
         binding.btnNext.setOnSingleClickListener {
             askNotificationPermission()
-            val userData = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                intent.getParcelableExtra("userData", User::class.java)
-            } else {
-                intent.getParcelableExtra<User>("userData")
-            }
-            setTime()
-            val questData = intent.getStringArrayExtra("questData")
-            setQuestList(questData)
-            viewModel.setSendInfo(userData, time, questList)
-            viewModel.isPostSuccess.observe(this) {
-                if (it) {
-                    setOnboardingBoolean(DID_USER_CLEAR_ONBOARD, true)
-                    setOnboardingBoolean(DID_USER_CLEAR_INVITE_CODE, true)
-                    startActivity(Intent(this, OnboardingFinishActivity::class.java))
-                } else {
-                    Snackbar.make(binding.root, R.string.fail_information_post, Snackbar.LENGTH_SHORT).show()
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/onboarding/SetTimeActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/onboarding/SetTimeActivity.kt
@@ -89,10 +89,7 @@ class SetTimeActivity : BindingActivity<ActivitySetTimeBinding>(R.layout.activit
                         getString(R.string.if_allow_notification),
                         Snackbar.LENGTH_SHORT
                     ).show()
-                    val intent =
-                        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).setData(Uri.parse("package:" + this.packageName))
-                    startActivity(intent)
-                    this.finish()
+                    sendUserData()
                 } else {
                     requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
                 }


### PR DESCRIPTION
## 🎀 Related Issues

#### close #103

## 🤔 What Did You Do
- [x] 시간 설정 후 버튼 클릭 시 알림 허용 버튼이 뜨기 전에 화면이 바로 넘어가는 현상 수정
- [x] 온보딩 완료 후 뒤로가기 버튼 두 번 클릭 시 오류 발생하면서 화면이 안 넘어가는 현상 수정

## ⁉️ etc
* 버튼이 뜨기 전에 Observer에서 변경사항을 감지하고 화면을 넘겨버린 것이 원인이었습니다. 그래서 팝업에서 권한 허용/비허용 둘 중 하나를 눌러야지만 변경사항을 감지할 수 있도록 코드 위치를 수정하였습니다.
* 시간 설정 완료 버튼을 누르면 서버에 모든 온보딩 정보가 등록되므로 등록하자마자 화면을 싹 지우는 것으로 오류를 수정했습니다.