### PR TITLE
[Feat/#107] 홈 화면 로딩뷰 추가

### DIFF
--- a/app/src/main/java/com/sopt/umbba_android/presentation/MainActivity.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/MainActivity.kt
@@ -1,10 +1,14 @@
 package com.sopt.umbba_android.presentation
 
+import android.content.Context
+import android.os.Build
 import android.os.Bundle
-import android.util.Log
+import android.view.View
 import androidx.fragment.app.Fragment
-import com.google.android.gms.tasks.OnCompleteListener
-import com.google.firebase.messaging.FirebaseMessaging
+import coil.ImageLoader
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
+import coil.load
 import com.sopt.umbba_android.R
 import com.sopt.umbba_android.databinding.ActivityMainBinding
 import com.sopt.umbba_android.presentation.home.HomeFragment
@@ -13,17 +17,34 @@ import com.sopt.umbba_android.presentation.setting.SettingFragment
 import com.sopt.umbba_android.util.binding.BindingActivity
 
 class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
+    private lateinit var context: Context
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        context = this
         initView()
+        initLoadingGif()
         setBottomNav()
     }
 
     private fun initView() {
+        setLoadingView()
         val currentFragment = supportFragmentManager.findFragmentById(R.id.fcv_main)
         if (currentFragment == null) {
             changeFragment(HomeFragment())
         }
+    }
+
+    private fun initLoadingGif() {
+        val imageLoader = ImageLoader.Builder(applicationContext)
+            .components {
+                if (Build.VERSION.SDK_INT >= 28) {
+                    add(ImageDecoderDecoder.Factory())
+                } else {
+                    add(GifDecoder.Factory())
+                }
+            }.build()
+
+        binding.ivLogoGif.load(R.raw.splash_logo, imageLoader = imageLoader)
     }
 
     private fun setBottomNav() {
@@ -31,7 +52,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             setOnItemSelectedListener {
                 changeFragment(
                     when (it.itemId) {
-                        R.id.menu_home -> HomeFragment()
+                        R.id.menu_home -> {
+                            setLoadingView()
+                            HomeFragment()
+                        }
                         R.id.menu_setting -> SettingFragment()
                         else -> ListFragment()
                     }
@@ -46,4 +70,10 @@ class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main
             .replace(R.id.fcv_main, fragment)
             .commit()
     }
+
+    private fun setLoadingView() {
+        binding.clLoading.visibility = View.VISIBLE
+    }
+
+    fun getLoadingView(): View = binding.clLoading
 }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/home/HomeFragment.kt
@@ -2,12 +2,16 @@ package com.sopt.umbba_android.presentation.home
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
 import coil.load
 import com.sopt.umbba_android.R
 import com.sopt.umbba_android.data.model.response.HomeCaseResponseDto
 import com.sopt.umbba_android.databinding.FragmentHomeBinding
+import com.sopt.umbba_android.presentation.MainActivity
 import com.sopt.umbba_android.presentation.home.viewmodel.HomeViewModel
 import com.sopt.umbba_android.presentation.qna.NoOpponentDialogFragment
 import com.sopt.umbba_android.presentation.qna.QuestionAnswerActivity
@@ -22,12 +26,16 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
         binding.vm = viewModel
         observeData()
     }
+
     private fun setClickEvent(responseCaseDto: HomeCaseResponseDto.HomeCaseData) {
         binding.btnAnswer.setOnSingleClickListener {
             viewModel.getResponseCase()
             when (responseCaseDto.responseCase) {
                 1 -> startActivity(Intent(requireActivity(), QuestionAnswerActivity::class.java))
-                2 -> showInviteDialog(responseCaseDto.inviteUserName.toString(), responseCaseDto.inviteCode.toString())
+                2 -> showInviteDialog(
+                    responseCaseDto.inviteUserName.toString(),
+                    responseCaseDto.inviteCode.toString()
+                )
                 3 -> showNoOpponentDialog()
             }
         }
@@ -66,6 +74,9 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
                 else -> R.drawable.bg_home5
             }
         )
+        Handler(Looper.getMainLooper()).postDelayed({
+            (activity as MainActivity).getLoadingView().visibility = View.INVISIBLE
+        }, 1000)
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/sopt/umbba_android/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/home/HomeFragment.kt
@@ -42,10 +42,10 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
     }
 
     private fun observeData() {
-        viewModel.homeData.observe(requireActivity()) {
+        viewModel.homeData.observe(viewLifecycleOwner) {
             setBackground(it.section)
         }
-        viewModel.responseCaseData.observe(requireActivity()) {
+        viewModel.responseCaseData.observe(viewLifecycleOwner) {
             setClickEvent(it)
         }
     }
@@ -75,7 +75,9 @@ class HomeFragment : BindingFragment<FragmentHomeBinding>(R.layout.fragment_home
             }
         )
         Handler(Looper.getMainLooper()).postDelayed({
-            (activity as MainActivity).getLoadingView().visibility = View.INVISIBLE
+            if (activity != null) {
+                (activity as MainActivity).getLoadingView().visibility = View.INVISIBLE
+            }
         }, 1000)
     }
 

--- a/app/src/main/java/com/sopt/umbba_android/presentation/list/ListFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/list/ListFragment.kt
@@ -24,7 +24,7 @@ class ListFragment : BindingFragment<FragmentListBinding>(R.layout.fragment_list
     }
 
     private fun observeData() {
-        viewModel.listResponseDto.observe(requireActivity()) {
+        viewModel.listResponseDto.observe(viewLifecycleOwner) {
             listQuestionAdapter.submitList(it)
         }
     }

--- a/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
+++ b/app/src/main/java/com/sopt/umbba_android/presentation/qna/ConfirmAnswerDialogFragment.kt
@@ -46,7 +46,7 @@ class ConfirmAnswerDialogFragment : DialogFragment() {
     }
 
     private fun observeResponseStatus() {
-        viewModel.responseStatus.observe(this) {
+        viewModel.responseStatus.observe(viewLifecycleOwner) {
             if (it == 201) {
                 dismiss()
                 requireActivity().finish()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -8,26 +8,51 @@
         android:layout_height="match_parent"
         tools:context=".presentation.MainActivity">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/fcv_main"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toTopOf="@id/bnv_main"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_height="match_parent">
 
-        <com.google.android.material.bottomnavigation.BottomNavigationView
-            android:id="@+id/bnv_main"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:background="@color/umbba_white"
-            app:itemActiveIndicatorStyle="@null"
-            app:itemBackground="@drawable/sel_bottom_nav_indicator"
-            app:itemIconSize="24dp"
-            app:itemIconTint="@color/sel_bottom_nav_icon"
-            app:itemTextColor="@color/sel_bottom_nav_text"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:menu="@menu/menu_bottom" />
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/fcv_main"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toTopOf="@id/bnv_main"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.bottomnavigation.BottomNavigationView
+                android:id="@+id/bnv_main"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:background="@color/umbba_white"
+                app:itemActiveIndicatorStyle="@null"
+                app:itemBackground="@drawable/sel_bottom_nav_indicator"
+                app:itemIconSize="24dp"
+                app:itemIconTint="@color/sel_bottom_nav_icon"
+                app:itemTextColor="@color/sel_bottom_nav_text"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:menu="@menu/menu_bottom" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/cl_loading"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="@color/umbba_black_opacity70"
+            android:visibility="visible">
+
+            <ImageView
+                android:id="@+id/iv_logo_gif"
+                android:layout_width="88dp"
+                android:layout_height="88dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
+
+
 </layout>

--- a/app/src/main/res/layout/fragment_invite_code_dialog.xml
+++ b/app/src/main/res/layout/fragment_invite_code_dialog.xml
@@ -75,7 +75,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="12dp"
-                android:text="umbbachoigo123"
+                tools:text="umbbachoigo123"
                 android:textColor="@color/umbba_black"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="error_red">#FF3A1F</color>
     <color name="success">#419277</color>
     <color name="umbba_black">#32211B</color>
+    <color name="umbba_black_opacity70">#B332211B</color>
     <color name="umbba_white">#FCFAF8</color>
 
     <color name="primary_400">#F1BD9B</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@
     <!--invite code dialog fragment-->
     <string name="not_have_partner">상대를 초대할 차례야\n상대방이 수락하면 문답이 시작돼</string>
     <string name="copy_invite_code">초대코드 복사</string>
-    <string name="send_invitation">카카오톡으로 초대 보내기</string>
+    <string name="send_invitation">초대장 보내기</string>
     <string name="copy_invite_code_snackbar">초대 코드가 복사되었습니다.</string>
     <string name="install_kakaotalk">카카오톡을 설치해주세요.</string>
     <string name="kakao_title">%s으로부터 초대가 왔어요.\n초대코드 : %s</string>


### PR DESCRIPTION
## 🎀 Related Issues

#### close #107 

## 🤔 What Did You Do
- [x]  로딩뷰 추가
- [x]  초대코드 공유하기 팝업 문구 수정
- [x] fragment liveData observe lifecycleOwner -> viewLifecycleOwner로 변경  

## 📸 Screenshot

https://github.com/Team-Umbba/Umbba-Android/assets/70602631/a8da98a1-dd21-4ae6-8a76-306f583a4e1b


## ⁉️ etc
- OB 멘토님 피드백에 따라 viewLifecycleOwner로 변경했습니다.
- 로딩뷰의 경우 figma 디자인대로 배경이 bottom navigation을 덮게 하기 위해 home fragment가 아닌 main에서 작업했습니다. 그리고 홈 fragment의 서버통신 성공 여부에 따라 main의 디자인 visible을 처리했습니다. 
- 이미지 통신이 빠르게 될 경우 delay를 걸지 않으면 로딩뷰가 굉장히 짧게 렉걸리듯이 (0.1초 정도) 뜨는게 오히려 사용자 경험을 해치는거 같아서 delay 를 걸어뒀습니다. 
- activity!=null 처리는 사용자가 계속 bottom nav home을 연타하면 activity가 생성되기도 전에 해당 메서드를 실행해야하는 null -point exception이 발생해서 처리한 부분입니다.